### PR TITLE
 fix for druids getting dected in vanilla parser

### DIFF
--- a/Backend/src/modules/live_data_processor/tools/cbl_parser/wow_vanilla/parser.rs
+++ b/Backend/src/modules/live_data_processor/tools/cbl_parser/wow_vanilla/parser.rs
@@ -1041,7 +1041,7 @@ impl CombatLogParser for WoWVanillaParser {
                     "shaman" => 7,
                     "mage" => 8,
                     "warlock" => 9,
-                    "Druid" => 11,
+                    "druid" => 11,
                     _ => return None,
                 });
             }


### PR DESCRIPTION
Capitalization causes druids to not be detected by the vanilla parser. This should fix that.
This does not fix druids that have already been saved to the database wrong.