### PR TITLE
grammar fix SPELLDISMISSPETOTHER

### DIFF
--- a/Addons/AdvancedVanillaCombatLog/core.lua
+++ b/Addons/AdvancedVanillaCombatLog/core.lua
@@ -637,6 +637,7 @@ function RPLL:fix_combat_log_strings()
     SPELLDEFLECTEDOTHERSELF = "%s" .. " 's %s was deflected by " .. player_name .. "."
     SPELLDEFLECTEDSELFOTHER = player_name .. " 's %s was deflected by %s."
     SPELLDEFLECTEDSELFSELF = player_name .. " 's %s was deflected by " .. player_name .. "."
+    SPELLDISMISSPETOTHER = "%s 's %s is dismissed."
     SPELLDISMISSPETSELF = player_name .. " 's %s is dismissed."
     SPELLDODGEDOTHERSELF = "%s" .. " 's %s was dodged by " .. player_name .. "."
     SPELLDODGEDSELFOTHER = player_name .. " 's %s was dodged by %s."


### PR DESCRIPTION
eg
```11/22 23:10:28.160  Yis's Rat is dismissed.```
should become
```11/22 23:10:28.160  Yis 's Rat is dismissed.```
to be consistent with all other log messages

It makes apostrophes less ambiguous for things like
Kreeg's Stout Beatdown
Kel'Thuzad
C'Thun
Quel'dorei
