### PR TITLE
Fix wrong string for resisted spells

### DIFF
--- a/Addons/AdvancedVanillaCombatLog/core.lua
+++ b/Addons/AdvancedVanillaCombatLog/core.lua
@@ -692,7 +692,7 @@ function RPLL:fix_combat_log_strings()
     SPELLREFLECTSELFOTHER = player_name .. " 's %s is reflected back by %s."
     SPELLREFLECTSELFSELF = player_name .. " 's %s is reflected back by " .. player_name .. "."
     SPELLRESISTOTHERSELF = "%s" .. " 's %s was resisted by " .. player_name .. "."
-    SPELLRESISTSELFOTHER = player_name .. " 's %s was resisted by " .. player_name .. "."
+    SPELLRESISTSELFOTHER = player_name .. " 's %s was resisted by %s."
     SPELLRESISTSELFSELF = player_name .. " 's %s was resisted by " .. player_name .. "."
     SPELLSPLITDAMAGEOTHERSELF = "%s" .. " 's %s causes " .. player_name .. " %d damage."
     SPELLSPLITDAMAGESELFOTHER = player_name .. " 's %s causes %s %d damage."


### PR DESCRIPTION
It was accidentally replacing the "Your spell was resisted by enemy" string to "your spell was resisted by yourself"

Before this PR:
![image](https://github.com/YamaYAML/LegacyPlayersV4/assets/111737968/d265189c-5d96-4010-bcf5-9b29caa0455e)

After this PR:
![image](https://github.com/YamaYAML/LegacyPlayersV4/assets/111737968/867c591b-bdb5-4fd4-be00-6d496aa89307)
